### PR TITLE
Added transparentTap to allow to target handle tap event

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Attributes:
 | `color` | Color | Custom color to target |
 | `enableOverlayTab` | bool | enable click in all screen to call next step |
 | `enableTargetTab` | bool | enable click in target to call next step |
+| `transparentTargetTap` | bool | enable click to call real target function instead of onClickTarget|
 | `alignSkip` | Alignment | use to align the skip in the target |
 | `paddingFocus` | Alignment | settings padding of the focus in target |
 | `focusAnimationDuration` | Duration | override the widget's global focus animation duration |

--- a/lib/src/paint/light_paint.dart
+++ b/lib/src/paint/light_paint.dart
@@ -29,7 +29,7 @@ class LightPaint extends CustomPainter {
     // gives the equivalent of `sweepAngle: 0`.  I couldn't find any documentation
     // of the expected behavior here, so instead I just call arcTo twice (two
     // semi-circles) to outline the full hole.
-    final path = Path()
+    path = Path()
       ..moveTo(0, 0)
       ..lineTo(0, positioned.dy)
       ..arcTo(
@@ -51,7 +51,7 @@ class LightPaint extends CustomPainter {
       ..close();
 
     canvas.drawPath(
-      path,
+      path!,
       Paint()
         ..style = PaintingStyle.fill
         ..color = colorShadow.withOpacity(opacityShadow),

--- a/lib/src/paint/light_paint.dart
+++ b/lib/src/paint/light_paint.dart
@@ -8,6 +8,7 @@ class LightPaint extends CustomPainter {
   final double sizeCircle;
   final Color colorShadow;
   final double opacityShadow;
+  Path? path;
 
   LightPaint(
     this.progress,
@@ -28,7 +29,7 @@ class LightPaint extends CustomPainter {
     // gives the equivalent of `sweepAngle: 0`.  I couldn't find any documentation
     // of the expected behavior here, so instead I just call arcTo twice (two
     // semi-circles) to outline the full hole.
-    final circleHole = Path()
+    final path = Path()
       ..moveTo(0, 0)
       ..lineTo(0, positioned.dy)
       ..arcTo(
@@ -50,11 +51,16 @@ class LightPaint extends CustomPainter {
       ..close();
 
     canvas.drawPath(
-      circleHole,
+      path,
       Paint()
         ..style = PaintingStyle.fill
         ..color = colorShadow.withOpacity(opacityShadow),
     );
+  }
+
+  @override
+  bool hitTest(Offset position) {
+    return path?.getBounds().contains(position) ?? false;
   }
 
   @override

--- a/lib/src/paint/light_paint.dart
+++ b/lib/src/paint/light_paint.dart
@@ -8,7 +8,7 @@ class LightPaint extends CustomPainter {
   final double sizeCircle;
   final Color colorShadow;
   final double opacityShadow;
-  Path? path;
+  Path? circleHole;
 
   LightPaint(
     this.progress,
@@ -29,7 +29,7 @@ class LightPaint extends CustomPainter {
     // gives the equivalent of `sweepAngle: 0`.  I couldn't find any documentation
     // of the expected behavior here, so instead I just call arcTo twice (two
     // semi-circles) to outline the full hole.
-    path = Path()
+    circleHole = Path()
       ..moveTo(0, 0)
       ..lineTo(0, positioned.dy)
       ..arcTo(
@@ -51,7 +51,7 @@ class LightPaint extends CustomPainter {
       ..close();
 
     canvas.drawPath(
-      path!,
+      circleHole!,
       Paint()
         ..style = PaintingStyle.fill
         ..color = colorShadow.withOpacity(opacityShadow),
@@ -60,7 +60,7 @@ class LightPaint extends CustomPainter {
 
   @override
   bool hitTest(Offset position) {
-    return path?.getBounds().contains(position) ?? false;
+    return circleHole?.getBounds().contains(position) ?? false;
   }
 
   @override

--- a/lib/src/paint/light_paint_rect.dart
+++ b/lib/src/paint/light_paint_rect.dart
@@ -11,6 +11,7 @@ class LightPaintRect extends CustomPainter {
   final double opacityShadow;
   final double offset;
   final double radius;
+  Path? path;
 
   LightPaintRect({
     required this.progress,
@@ -103,14 +104,21 @@ class LightPaintRect extends CustomPainter {
 
     double h = maxSize * (1 - progress) + target.size.height + offset;
 
+    path = radius > 0
+        ? _drawRRectHole(size, x, y, w, h, radius)
+        : _drawRectHole(size, x, y, w, h);
+
     canvas.drawPath(
-      radius > 0
-          ? _drawRRectHole(size, x, y, w, h, radius)
-          : _drawRectHole(size, x, y, w, h),
+      path!,
       Paint()
         ..style = PaintingStyle.fill
         ..color = colorShadow.withOpacity(opacityShadow),
     );
+  }
+
+  @override
+  bool hitTest(Offset position) {
+    return path?.contains(position) ?? false;
   }
 
   @override

--- a/lib/src/target/target_focus.dart
+++ b/lib/src/target/target_focus.dart
@@ -14,6 +14,7 @@ class TargetFocus {
     this.color,
     this.enableOverlayTab = false,
     this.enableTargetTab = true,
+    this.transparentTargetTap = false,
     this.alignSkip,
     this.paddingFocus,
     this.focusAnimationDuration,
@@ -28,6 +29,7 @@ class TargetFocus {
   final double? radius;
   final bool enableOverlayTab;
   final bool enableTargetTab;
+  final bool transparentTargetTap;
   final Color? color;
   final AlignmentGeometry? alignSkip;
   final double? paddingFocus;

--- a/lib/src/widgets/animated_focus_light.dart
+++ b/lib/src/widgets/animated_focus_light.dart
@@ -98,29 +98,28 @@ class AnimatedFocusLightState extends State<AnimatedFocusLight>
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(
-      onTap: _targetFocus.enableOverlayTab
-          ? () => _tapHandler(overlayTap: true)
-          : null,
-      child: AnimatedBuilder(
-        animation: _controller,
-        builder: (_, child) {
-          _progressAnimated = _curvedAnimation.value;
-          return AnimatedBuilder(
-            animation: _controllerPulse,
-            builder: (_, child) {
-              if (_finishFocus) {
-                _progressAnimated = _tweenPulse.value;
-              }
-              return Stack(
-                children: <Widget>[
-                  Container(
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (_, child) {
+        _progressAnimated = _curvedAnimation.value;
+        return AnimatedBuilder(
+          animation: _controllerPulse,
+          builder: (_, child) {
+            if (_finishFocus) {
+              _progressAnimated = _tweenPulse.value;
+            }
+            return Stack(
+              children: <Widget>[
+                GestureDetector(
+                  child: Container(
                     width: double.maxFinite,
                     height: double.maxFinite,
                     child: CustomPaint(
                       painter: _getPainter(_targetFocus),
                     ),
                   ),
+                ),
+                if (!_targetFocus.transparentTargetTap)
                   Positioned(
                     left: (_targetPosition?.offset.dx ?? 0) -
                         _getPaddingFocus() * 2,
@@ -140,12 +139,11 @@ class AnimatedFocusLightState extends State<AnimatedFocusLight>
                       ),
                     ),
                   )
-                ],
-              );
-            },
-          );
-        },
-      ),
+              ],
+            );
+          },
+        );
+      },
     );
   }
 


### PR DESCRIPTION
Related to this issue #76 the attribute targetTransparentTap is added with which user can decide if when tapping on the target the method sent to the onClickTarget attribute is executed or the real function of the target is executed, this being useful when the target has several buttons.